### PR TITLE
 support build when using lerna with on package

### DIFF
--- a/packages/dev/scripts/polkadot-dev-build-ts.sh
+++ b/packages/dev/scripts/polkadot-dev-build-ts.sh
@@ -39,6 +39,12 @@ function build_js () {
       cpx "../../build/$ROOT/src/**/*.d.ts" build
     fi
 
+    # lerna one package
+    if [ -d "../../build/src" ]; then
+      cpx "../../build/src/**/*.d.ts" build
+    fi
+
+    # lerna multiple packages
     if [ -d "../../build/packages/$ROOT/src" ]; then
       cpx "../../build/packages/$ROOT/src/**/*.d.ts" build
     fi


### PR DESCRIPTION
Hi, I am using this build script and found it won't copy the d.ts files from `./build` to `./packages/[package_name]/build` if it's using Lerna and only have one package in packages(maybe I shouldn't use lerna if I only have one package... but there are some benefits to use Lerna even if there is only one package such as for easier to extend in the future...). So I added three lines code to make this script support the case above. Please let me know if you guys don't need these code, I will just close this PR.