### PR TITLE
Include dotfiles (.nojekyll) when pushing to gh-pages

### DIFF
--- a/packages/dev/scripts/polkadot-dev-ghact-docs.sh
+++ b/packages/dev/scripts/polkadot-dev-ghact-docs.sh
@@ -35,7 +35,7 @@ function deploy_pages () {
   echo ""
   echo "*** Publishing to GitHub Pages"
 
-  yarn run gh-pages --repo $REPO --dist $GH_PAGES_SRC --dest .
+  yarn run gh-pages --dotfiles --repo $REPO --dist $GH_PAGES_SRC --dest .
 
   echo ""
   echo "*** GitHub Pages completed"


### PR DESCRIPTION
Should fix https://github.com/polkadot-js/api/issues/1655. The `gh-pages` branch is missing the `.nojekyll` file (even though `build-docs` has the `.nojekyll` file), making pages starting with `_` inaccessible.

```
Usage: gh-pages [options]

Options:
  [...]
  -t, --dotfiles           Include dotfiles
```