### PR TITLE
eslint import padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "polkadot-dev-build-ts && node ./tester.cjs && node ./tester.mjs && (cd packages/dev && copyfiles config/* scripts/* build)",
     "build:release": "polkadot-ci-ghact-build --skip-beta",
     "docs": "polkadot-dev-build-docs",
-    "lint": "polkadot-dev-run-lint",
+    "lint": "polkadot-dev-run-lint --fix",
     "clean": "polkadot-dev-clean-build",
     "postinstall": "./packages/dev/scripts/polkadot-dev-yarn-only.cjs",
     "test": "polkadot-dev-run-test --coverage"

--- a/packages/dev/config/eslint.cjs
+++ b/packages/dev/config/eslint.cjs
@@ -61,7 +61,7 @@ module.exports = {
     'header/header': [2, 'line', [
       { pattern: ' Copyright \\d{4}(-\\d{4})? @polkadot/' },
       ' SPDX-License-Identifier: Apache-2.0'
-    ]],
+    ], 2],
     'jsx-quotes': ['error', 'prefer-single'],
     'react/prop-types': [0], // this is a completely broken rule
     'object-curly-newline': ['error', {

--- a/packages/dev/config/eslint.cjs
+++ b/packages/dev/config/eslint.cjs
@@ -77,7 +77,10 @@ module.exports = {
       { blankLine: 'always', prev: 'function', next: '*' },
       { blankLine: 'always', prev: '*', next: 'try' },
       { blankLine: 'always', prev: 'try', next: '*' },
-      { blankLine: 'always', prev: '*', next: 'return' }
+      { blankLine: 'always', prev: '*', next: 'return' },
+      { blankLine: 'always', prev: '*', next: 'import' },
+      { blankLine: 'always', prev: 'import', next: '*' },
+      { blankLine: 'any', prev: 'import', next: 'import' }
     ],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'error',

--- a/packages/dev/src/Component.tsx
+++ b/packages/dev/src/Component.tsx
@@ -1,5 +1,6 @@
 // Copyright 2017-2020 @polkadot/dev authors & contributors
 // SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 
 interface Props {

--- a/packages/dev/src/Component.tsx
+++ b/packages/dev/src/Component.tsx
@@ -1,6 +1,5 @@
 // Copyright 2017-2020 @polkadot/dev authors & contributors
 // SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 
 interface Props {

--- a/packages/dev/src/index.ts
+++ b/packages/dev/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2020 @polkadot/dev authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { EchoString } from './types';
+import type { EchoString } from './types';
 
 import { adder, blah } from './test1';
 import { foo } from './test1/foo';

--- a/packages/dev/src/test1/bar.ts
+++ b/packages/dev/src/test1/bar.ts
@@ -1,2 +1,4 @@
 // Copyright 2017-2020 @polkadot/dev authors & contributors
 // SPDX-License-Identifier: Apache-2.0
+
+console.log('something');

--- a/packages/dev/src/test1/circ1.ts
+++ b/packages/dev/src/test1/circ1.ts
@@ -4,7 +4,7 @@
 import circ2 from './circ2';
 
 // we leave this as a warning... just a test
-export default function circ1 () {
+export default function circ1 (): number {
   circ2();
 
   return 123;


### PR DESCRIPTION
Attempts to fix https://github.com/polkadot-js/apps/pull/4137#discussion_r537320332 

Additionally also does enforce a new line after import blocks, which helps.