### PR TITLE
Add babel plugin for automatically add extensions (.js) in imports from typescript 

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -97,6 +97,7 @@
     "@types/node": "^15.12.4",
     "@types/react": "^17.0.11",
     "@types/yargs": "^17.0.0",
+    "babel-plugin-add-import-extension": "^1.5.1",
     "react": "^17.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,6 +1876,7 @@ __metadata:
     "@typescript-eslint/parser": 4.28.0
     "@vue/component-compiler-utils": ^3.2.2
     babel-jest: ^27.0.5
+    babel-plugin-add-import-extension: ^1.5.1
     babel-plugin-module-extension-resolver: ^1.0.0-rc.2
     babel-plugin-module-resolver: ^4.1.0
     babel-plugin-styled-components: ^1.12.0
@@ -2736,6 +2737,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.8.0
   checksum: 565e2b39d651dc2cfdb873bd78edc9595a6954106683a75f5ce8f5cee8e44ee2aa8e08e8844e1c67dce036bf6a23cf95a358a7a750be2a0af7f0ec4ed4199af4
+  languageName: node
+  linkType: hard
+
+"babel-plugin-add-import-extension@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "babel-plugin-add-import-extension@npm:1.5.1"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.13.0
+  peerDependencies:
+    "@babel/core": ">=7.0.0"
+  checksum: 662ee88a3f9f42dadf88d70366d12df774854c7899602eafbcb4c79b6c84097268bfec45a6693d390b17627f50481c7ce7a5fe0bc779e437395ac35b8db3fcde
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
While building the [integration of substrate connect with apps](https://github.com/polkadot-js/apps/pull/5644) there was an update of substrate-connect to use ts-jest (instead of jest on transpiled dist dir). 

Substrate connect is built with Typescript and in order to integrate with apps I had to add the `.js` extension manually on some imports of  `.ts` files. That was a hack-y way to overcome the transpiling

After the update though from `jest` on dist directory to `ts-jest` (since now it supports esm) the `.js` had to be removed, as `ts-jest` could not be executed.

This PR, introduces a babel plugin called [babel-plugin-add-import-extension](https://www.npmjs.com/package/babel-plugin-add-import-extension) that automatically adds the '.js' extension in imports/exports for TS projects 