### PR TITLE
/src/ import linting

### DIFF
--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -251,6 +251,10 @@ export const packageInfo = { name: '${name}', version: '${version}' };
   }
 }
 
+function lintError (full, line, lineNumber, error) {
+  throw new Error(`${full.split('/packages/')[1]}:: line ${lineNumber + 1}:: ${error}:: \n\n\t${line}\n`);
+}
+
 function lintOutput (dir) {
   fs
     .readdirSync(dir)
@@ -263,9 +267,9 @@ function lintOutput (dir) {
         fs
           .readFileSync(full, 'utf-8')
           .split('\n')
-          .forEach((line, index) => {
+          .forEach((line, lineNumber) => {
             if (line.includes('import') && line.includes('/src/')) {
-              throw new Error(`${full.split('/packages/')[1]}:: line ${index + 1}:: /src/ import:: \n\n\t${line}\n`);
+              lintError(full, line, lineNumber, 'invalid /src/ import');
             }
           });
       }

--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -251,14 +251,14 @@ export const packageInfo = { name: '${name}', version: '${version}' };
   }
 }
 
-function lintOutput (pkg, dir) {
+function lintOutput (dir) {
   fs
     .readdirSync(dir)
     .forEach((sub) => {
       const full = path.join(dir, sub);
 
       if (fs.statSync(full).isDirectory()) {
-        lintOutput(pkg, full);
+        lintOutput(full);
       } else if (full.endsWith('.d.ts') || full.endsWith('.js') || full.endsWith('.cjs')) {
         fs
           .readFileSync(full, 'utf-8')
@@ -303,7 +303,7 @@ async function main () {
     const buildPath = path.join(process.cwd(), 'build');
 
     if (fs.existsSync(buildPath)) {
-      lintOutput(dir, buildPath);
+      lintOutput(buildPath);
     }
 
     process.chdir('..');

--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -265,7 +265,7 @@ function lintOutput (dir) {
           .split('\n')
           .forEach((line, index) => {
             if (line.includes('import') && line.includes('/src/')) {
-              throw new Error(`${full.split('/packages/')[1]}:: line ${index + 1}:: /src/ import:: ${line}`);
+              throw new Error(`${full.split('/packages/')[1]}:: line ${index + 1}:: /src/ import:: \n\n\t${line}\n`);
             }
           });
       }

--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -265,9 +265,7 @@ function lintOutput (pkg, dir) {
           .split('\n')
           .forEach((line, index) => {
             if (line.includes('import') && line.includes('/src/')) {
-              const path = full.split('/packages/')[1];
-
-              throw new Error(`${path}:: line ${index + 1}:: /src/ import:: ${line}`);
+              throw new Error(`${full.split('/packages/')[1]}:: line ${index + 1}:: /src/ import:: ${line}`);
             }
           });
       }

--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -251,6 +251,29 @@ export const packageInfo = { name: '${name}', version: '${version}' };
   }
 }
 
+function lintOutput (pkg, dir) {
+  fs
+    .readdirSync(dir)
+    .forEach((sub) => {
+      const full = path.join(dir, sub);
+
+      if (fs.statSync(full).isDirectory()) {
+        lintOutput(pkg, full);
+      } else if (full.endsWith('.d.ts') || full.endsWith('.js') || full.endsWith('.cjs')) {
+        fs
+          .readFileSync(full, 'utf-8')
+          .split('\n')
+          .forEach((line, index) => {
+            if (line.includes('import') && line.includes('/src/')) {
+              const path = full.split('/packages/')[1];
+
+              throw new Error(`${path}:: line ${index + 1}:: /src/ import:: ${line}`);
+            }
+          });
+      }
+    });
+}
+
 async function main () {
   execSync('yarn polkadot-dev-clean-build');
 
@@ -278,6 +301,12 @@ async function main () {
     process.chdir(dir);
 
     await buildJs(repoPath, dir);
+
+    const buildPath = path.join(process.cwd(), 'build');
+
+    if (fs.existsSync(buildPath)) {
+      lintOutput(dir, buildPath);
+    }
 
     process.chdir('..');
   }


### PR DESCRIPTION
Closes https://github.com/polkadot-js/dev/issues/512 (prevents https://github.com/polkadot-js/common/issues/1225)

(tested agains the problematic util-crypto branch)

```
*** @polkadot/util-crypto 7.9.1
Successfully compiled 236 files with Babel (1734ms).
Successfully compiled 236 files with Babel (855ms).

Error: util-crypto/build/base32/bs32.d.ts:: line 26:: invalid /src/ import:: 

	export declare const base32Encode: (value: import("../../../util/src/types").U8aLike, ipfsCompat?: boolean | undefined) => string;
```