### PR TITLE
Fix Vite build bundling error about EISDIR on `new URL('.', import.meta.url)`

### DIFF
--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -147,7 +147,7 @@ function tweakPackageInfo (buildDir) {
   // Hack around some bundler issues, in this case Vite which has import.meta.url
   // as undefined in production contexts (and subsequently makes URL fail)
   // See https://github.com/vitejs/vite/issues/5558
-  const esmDirname = "(import.meta && import.meta.url) ? new URL('.', import.meta.url).pathname : 'auto'";
+  const esmDirname = "(import.meta && import.meta.url) ? new URL(import.meta.url).pathname.substring(0, new URL(import.meta.url).pathname.lastIndexOf('/') + 1) : 'auto'";
   const cjsDirname = "typeof __dirname === 'string' ? __dirname : 'auto'";
 
   ['js', 'cjs'].forEach((ext) => {


### PR DESCRIPTION
Hi!
Vite shows EISDIR error at `new URL('.', import.meta.url)` expression on build.
Actually checking import.meta.url is not enough to fix this problem.
The problem is when bundler tries to build the code in production build, in compile time it has no idea about how the expression `new URL('.', import.meta.url)` should be resolved in runtime. And it tries to read all the file and bake it inline in base64 form. And in case of `new URL('.', ...)` it tries to read the dir what is impossible and throws compile-time error EISDIR. 

 So I created a workaround code which gives the same output in Vite and Node.js environments:

```js
const filePathname = new URL(import.meta.url).pathname
const folderPathname = filePathname.substring(0, filePathname.lastIndexOf('/')+1)
```

actually does literally the same as 

```js
new URL('.', import.meta.url).pathname
```

Regarding webpack - it's a bit more complicated.

Now webpack compiles `new URL('.', import.meta.url).pathname` to something like `/1247de54f5a6c6dbd.js`.
Obviously it doesn't make sense still `'.'` clearly describes desired result as a path to some folder. So current webpack behaviour is useless still it doesn't help to get a path to the package folder.

But this is an obvious and strange workaround from the webpack. Because without such config option, webpack just compiles whole path to the lib folder on the compiling machine. There is a closed [PR](https://github.com/webpack/webpack/pull/15246) and such option may be switched on in webpack config:
```
module: {
  parser: {
    javascript: {importMeta: false}
  }
}
```

With that option, workaround works really good and really provides a path to the folder (actually a plain '/', but it makes sense and it is the desired behaviour of `new URL('.', import.meta.url).pathname` expression).

Without that option it compiles to something like `/Users/user/projects/project/node_modules/@polkadot/x-global'.

Also closes https://github.com/polkadot-js/extension/issues/1018

BTW, @jacogr, could you please describe what the purpose of this code at all? I'm not sure why packages should provide information about themselves not via standard mechanics of import/require?