### PR TITLE
Fix createBundle for substrate connect

### DIFF
--- a/packages/dev/config/rollup.js
+++ b/packages/dev/config/rollup.js
@@ -38,23 +38,19 @@ export function createInput (pkg, _index) {
 export function createOutput (_pkg, external, globals) {
   const pkg = sanitizePkg(_pkg);
 
-  let settings = {
+  // inlineDynamicImports is used for multi-chunk builds as it creates a single bundle when dynamic imports are used
+  return {
     file: `packages/${pkg}/build/bundle-polkadot-${pkg}.js`,
     format: 'umd',
     globals: external.reduce((all, pkg) => ({
       [pkg]: createName(pkg),
       ...all
     }), { ...globals }),
+    inlineDynamicImports: true,
     intro: 'const global = window;',
     name: createName(_pkg),
     preferConst: true
   };
-
-  if (pkg === 'rpc-provider') {
-    settings = { ...settings, inlineDynamicImports: true };
-  }
-
-  return settings;
 }
 
 export function createBundle ({ entries = {}, external, globals = {}, index, inject = {}, pkg }) {

--- a/packages/dev/config/rollup.js
+++ b/packages/dev/config/rollup.js
@@ -38,7 +38,7 @@ export function createInput (pkg, _index) {
 export function createOutput (_pkg, external, globals) {
   const pkg = sanitizePkg(_pkg);
 
-  return {
+  let settings = {
     file: `packages/${pkg}/build/bundle-polkadot-${pkg}.js`,
     format: 'umd',
     globals: external.reduce((all, pkg) => ({
@@ -48,7 +48,13 @@ export function createOutput (_pkg, external, globals) {
     intro: 'const global = window;',
     name: createName(_pkg),
     preferConst: true
-  };
+  }
+
+  if (pkg === 'rpc-provider') {
+    settings = {...settings, inlineDynamicImports: true}
+  }
+
+  return settings;
 }
 
 export function createBundle ({ entries = {}, external, globals = {}, index, inject = {}, pkg }) {

--- a/packages/dev/config/rollup.js
+++ b/packages/dev/config/rollup.js
@@ -48,10 +48,10 @@ export function createOutput (_pkg, external, globals) {
     intro: 'const global = window;',
     name: createName(_pkg),
     preferConst: true
-  }
+  };
 
   if (pkg === 'rpc-provider') {
-    settings = {...settings, inlineDynamicImports: true}
+    settings = { ...settings, inlineDynamicImports: true };
   }
 
   return settings;


### PR DESCRIPTION
Due to the fact that substrate connect is `multiple chunks` generated build, the `inlineDynamicImports` needs to be activated for it to be build correctly in a file. I preferred to avoid adding that for all bundles.

@jacogr let me know if it is preferable the option `inlineDynamicImports` to be added in all bundles. 