### PR TITLE
Downgrade rollup node resolve

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -64,7 +64,7 @@
     "@rollup/plugin-dynamic-import-vars": "^1.4.4",
     "@rollup/plugin-inject": "^4.0.4",
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^14.0.0",
+    "@rollup/plugin-node-resolve": "^13.3.0",
     "@rushstack/eslint-patch": "^1.1.4",
     "@typescript-eslint/eslint-plugin": "5.36.2",
     "@typescript-eslint/parser": "5.36.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,7 +2012,7 @@ __metadata:
     "@rollup/plugin-dynamic-import-vars": ^1.4.4
     "@rollup/plugin-inject": ^4.0.4
     "@rollup/plugin-json": ^4.1.0
-    "@rollup/plugin-node-resolve": ^14.0.0
+    "@rollup/plugin-node-resolve": ^13.3.0
     "@rushstack/eslint-patch": ^1.1.4
     "@types/jest": ^29.0.0
     "@types/node": ^18.7.15
@@ -2224,9 +2224,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-node-resolve@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "@rollup/plugin-node-resolve@npm:14.0.0"
+"@rollup/plugin-node-resolve@npm:^13.3.0":
+  version: 13.3.0
+  resolution: "@rollup/plugin-node-resolve@npm:13.3.0"
   dependencies:
     "@rollup/pluginutils": ^3.1.0
     "@types/resolve": 1.17.1
@@ -2235,8 +2235,8 @@ __metadata:
     is-module: ^1.0.0
     resolve: ^1.19.0
   peerDependencies:
-    rollup: ^2.78.0
-  checksum: c40e7db6c36fd34d699904e8fdf87e550d608d1fe99f2004eda0251d2e436934a901336730eedcb051c2a0c600ee3fc3173b9a2013968247de1fda06fb0a6605
+    rollup: ^2.42.0
+  checksum: ec5418e6b3c23a9e30683056b3010e9d325316dcfae93fbc673ae64dad8e56a2ce761c15c48f5e2dcfe0c822fdc4a4905ee6346e3dcf90603ba2260afef5a5e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The semver package has circular deps which then breaks due to this https://github.com/rollup/plugins/issues/1258 

(See an example of the breakage here https://github.com/polkadot-js/common/runs/8225532412?check_suite_focus=true)