### PR TITLE
Require .js extensions for all imports

### DIFF
--- a/packages/dev/config/eslint.cjs
+++ b/packages/dev/config/eslint.cjs
@@ -64,6 +64,12 @@ module.exports = {
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off'
       }
+    },
+    {
+      files: 'mod.ts',
+      rules: {
+        'import/extensions': 'off'
+      }
     }
   ],
   parser: require.resolve('@typescript-eslint/parser'),
@@ -100,6 +106,10 @@ module.exports = {
       { pattern: ` Copyright 20(17|18|19|20|21|22)(-${new Date().getFullYear()})? @polkadot/` },
       ' SPDX-License-Identifier: Apache-2.0'
     ], 2],
+    'import/extensions': ['error', 'ignorePackages', {
+      json: 'always',
+      jsx: 'never'
+    }],
     'import-newlines/enforce': ['error', 2048],
     'jsx-quotes': ['error', 'prefer-single'],
     'react/prop-types': [0], // this is a completely broken rule

--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -478,25 +478,17 @@ function findFiles (buildDir, extra = '', exclude = []) {
 }
 
 function tweakCjsPaths () {
-  const cjsDir = 'build/cjs';
-
-  fs
-    .readdirSync(cjsDir)
-    .filter((n) => n.endsWith('.js'))
-    .forEach((jsName) => {
-      const thisPath = path.join(cjsDir, jsName);
-
-      fs.writeFileSync(
-        thisPath,
-        fs
-          .readFileSync(thisPath, 'utf8')
-          .replace(
-            // require("@polkadot/$1/$2")
-            /require\("@polkadot\/([a-z-]*)\/(.*)"\)/g,
-            'require("@polkadot/$1/cjs/$2")'
-          )
-      );
-    });
+  readdirSync('build/cjs', ['.js']).forEach((thisPath) => {
+    fs.writeFileSync(
+      thisPath,
+      fs
+        .readFileSync(thisPath, 'utf8')
+        .replace(
+          /require\("@polkadot\/([a-z-]*)\/(.*)"\)/g,
+          'require("@polkadot/$1/cjs/$2")'
+        )
+    );
+  });
 }
 
 function tweakPackageInfo (compileType) {

--- a/packages/dev/src/node/ts/resolver.mjs
+++ b/packages/dev/src/node/ts/resolver.mjs
@@ -21,23 +21,6 @@ import { tsAliases } from './tsconfig.mjs';
 /** @typedef {{ parentURL: string }} Context */
 /** @typedef {{ format: 'commonjs' | 'json' | 'module'; shortCircuit?: boolean; url: string }} Resolved */
 /** @typedef {(specifier: string, context: Context) => Resolved | undefined} Resolver */
-/** @typedef {{ extJs?: boolean; extJson?: boolean; extTs?: boolean; pathAlias?: boolean; pathRelative?: boolean }} Allow */
-
-// the resolution modes we actually support here
-// (on a per-function basis we do allow overrides for testing)
-/** @type {Allow} */
-const ALLOW = {
-  // we don't use the import x from './somewhere.js' form in polkadot-js
-  extJs: false,
-  // this is used extensively in the polkadot-js/api repo
-  extJson: true,
-  // the reason for this actual resolver, so always true
-  extTs: true,
-  // alias definitions are used in all polkadot-js projects
-  pathAlias: true,
-  // relative extensionless imports (files and directories) are used
-  pathRelative: true
-};
 
 /**
  * @internal
@@ -67,12 +50,11 @@ function getParentPath (parentUrl) {
  *
  * @param {string} specifier
  * @param {URL | string} parentUrl
- * @param {Allow} [allow]
  * @returns {Resolved | undefined}
  **/
-export function resolveExtTs (specifier, parentUrl, allow = ALLOW) {
+export function resolveExtTs (specifier, parentUrl) {
   // handle .ts extensions directly
-  if (allow.extTs && EXT_TS_REGEX.test(specifier)) {
+  if (EXT_TS_REGEX.test(specifier)) {
     return {
       format: 'module',
       shortCircuit: true,
@@ -89,13 +71,12 @@ export function resolveExtTs (specifier, parentUrl, allow = ALLOW) {
  *
  * @param {string} specifier
  * @param {URL | string} parentUrl
- * @param {Allow} [allow]
  * @returns {Resolved | undefined}
  **/
-export function resolveExtJs (specifier, parentUrl, allow = ALLOW) {
+export function resolveExtJs (specifier, parentUrl) {
   // handle ts imports where import *.js -> *.ts
   // (unlike the ts resolution, we only cater for relative paths)
-  if (allow.extJs && specifier.startsWith('.') && EXT_JS_REGEX.test(specifier)) {
+  if (specifier.startsWith('.') && EXT_JS_REGEX.test(specifier)) {
     const full = fileURLToPath(new URL(specifier, parentUrl));
 
     // when it doesn't exist, we try and see if a source replacement helps
@@ -122,11 +103,10 @@ export function resolveExtJs (specifier, parentUrl, allow = ALLOW) {
  *
  * @param {string} specifier
  * @param {URL | string} parentUrl
- * @param {Allow} [allow]
  * @returns {Resolved | undefined}
  */
-export function resolveExtJson (specifier, parentUrl, allow = ALLOW) {
-  if (allow.extJson && specifier.startsWith('.') && EXT_JSON_REGEX.test(specifier)) {
+export function resolveExtJson (specifier, parentUrl) {
+  if (specifier.startsWith('.') && EXT_JSON_REGEX.test(specifier)) {
     const { parentDir } = getParentPath(parentUrl);
     const jsonPath = path.join(parentDir, specifier);
 
@@ -154,11 +134,10 @@ export function resolveExtJson (specifier, parentUrl, allow = ALLOW) {
  *
  * @param {string} specifier
  * @param {URL | string} parentUrl
- * @param {Allow} [allow]
  * @returns {Resolved | undefined}
  **/
-export function resolveRelative (specifier, parentUrl, allow = ALLOW) {
-  if (allow.pathRelative && specifier.startsWith('.')) {
+export function resolveExtBare (specifier, parentUrl) {
+  if (specifier.startsWith('.')) {
     const { parentDir, parentPath } = getParentPath(parentUrl);
     const found = specifier === '.'
       ? (
@@ -199,47 +178,45 @@ export function resolveRelative (specifier, parentUrl, allow = ALLOW) {
  *
  * @param {string} specifier
  * @param {URL | string} parentUrl
- * @param {Allow} [allow]
  * @param {typeof tsAliases} [aliases]
  * @returns {Resolved | undefined}
  **/
-export function resolveAliases (specifier, parentUrl, allow = ALLOW, aliases = tsAliases) {
-  if (allow.pathAlias) {
-    const parts = specifier.split(/[\\/]/);
-    const found = aliases
-      // return a [filter, [...partIndex]] mapping
-      .map((alias) => ({
-        alias,
-        indexes: parts
-          .map((_, i) => i)
-          .filter((start) =>
-            // parts should have more entries than the wildcard
-            parts.length >= alias.filter.length &&
-            // match all parts of the alias (excluding last wilcard)
-            alias.filter.every((f, i) =>
-              parts[start + i] &&
-              parts[start + i] === f
-            )
+export function resolveAliases (specifier, parentUrl, aliases = tsAliases) {
+  const parts = specifier.split(/[\\/]/);
+  const found = aliases
+    // return a [filter, [...partIndex]] mapping
+    .map((alias) => ({
+      alias,
+      indexes: parts
+        .map((_, i) => i)
+        .filter((start) =>
+          // parts should have more entries than the wildcard
+          parts.length >= alias.filter.length &&
+          // match all parts of the alias (excluding last wilcard)
+          alias.filter.every((f, i) =>
+            parts[start + i] &&
+            parts[start + i] === f
           )
-      }))
-      // we only return the first
-      .find(({ indexes }) => indexes.length);
+        )
+    }))
+    // we only return the first
+    .find(({ indexes }) => indexes.length);
 
-    if (found) {
-      // get the initial parts
-      const initial = parts.slice(found.alias.filter.length);
-      const newSpecifier = initial.length
-        ? `./${path.join(...initial)}`
-        : '.';
-      const newParentUrl = pathToFileURL(found.alias.path).href;
+  if (found) {
+    // get the initial parts
+    const initial = parts.slice(found.alias.filter.length);
+    const newSpecifier = initial.length
+      ? `./${path.join(...initial)}`
+      : '.';
+    const newParentUrl = pathToFileURL(found.alias.path).href;
 
-      // do the actual alias resolution
-      return (
-        resolveRelative(newSpecifier, newParentUrl, allow) ||
-        resolveExtJs(newSpecifier, newParentUrl, allow) ||
-        resolveExtJson(newSpecifier, newParentUrl, allow)
-      );
-    }
+    // do the actual alias resolution
+    return (
+      resolveExtBare(newSpecifier, newParentUrl) ||
+      resolveExtTs(newSpecifier, newParentUrl) ||
+      resolveExtJs(newSpecifier, newParentUrl) ||
+      resolveExtJson(newSpecifier, newParentUrl)
+    );
   }
 }
 
@@ -260,11 +237,13 @@ export function resolve (specifier, context, nextResolve) {
   const parentUrl = context.parentURL || CWD_URL;
 
   return (
-    resolveExtTs(specifier, parentUrl) ||
-    resolveRelative(specifier, parentUrl) ||
-    resolveAliases(specifier, parentUrl) ||
     resolveExtJs(specifier, parentUrl) ||
     resolveExtJson(specifier, parentUrl) ||
+    resolveAliases(specifier, parentUrl) ||
+    // use internally in aliases, avoided top-level
+    // resolveExtBare(specifier, parentUrl) ||
+    // unused (currently) in source imports
+    // resolveExtTs(specifier, parentUrl) ||
     nextResolve(specifier, context)
   );
 }

--- a/packages/dev/src/node/ts/resolver.test.mjs
+++ b/packages/dev/src/node/ts/resolver.test.mjs
@@ -9,7 +9,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { CWD_PATH } from './common.mjs';
-import { resolveExtJs, resolveExtJson, resolveExtTs, resolveRelative } from './resolver.mjs';
+import { resolveAliases, resolveExtBare, resolveExtJs, resolveExtJson, resolveExtTs } from './resolver.mjs';
 
 const ROOT_URL = pathToFileURL(`${CWD_PATH}/`);
 const SRC_PATH = 'packages/dev/src';
@@ -44,19 +44,19 @@ describe('resolveExtJs', () => {
 
   it('returns the correct value for ./mod.js resolution', () => {
     expect(
-      resolveExtJs('./mod.js', SRC_URL, { extJs: true })
+      resolveExtJs('./mod.js', SRC_URL)
     ).toEqual(modFound);
   });
 
   it('returns the correct value for ../mod.js resolution', () => {
     expect(
-      resolveExtJs('../mod.js', pathToFileURL(`${CWD_PATH}/${SRC_PATH}/rootJs/index.ts`), { extJs: true })
+      resolveExtJs('../mod.js', pathToFileURL(`${CWD_PATH}/${SRC_PATH}/rootJs/index.ts`))
     ).toEqual(modFound);
   });
 
   it('returns a correct object for a .jsx extension', () => {
     expect(
-      resolveExtJs(`./${SRC_PATH}/rootJs/Jsx.jsx`, ROOT_URL, { extJs: true })
+      resolveExtJs(`./${SRC_PATH}/rootJs/Jsx.jsx`, ROOT_URL)
     ).toEqual({
       format: 'module',
       shortCircuit: true,
@@ -68,7 +68,7 @@ describe('resolveExtJs', () => {
 describe('resolveExtJson', () => {
   it('resolves .json files', () => {
     expect(
-      resolveExtJson('../package.json', SRC_URL, { extJson: true })
+      resolveExtJson('../package.json', SRC_URL)
     ).toEqual({
       format: 'json',
       shortCircuit: true,
@@ -77,7 +77,7 @@ describe('resolveExtJson', () => {
   });
 });
 
-describe('resolveRelative', () => {
+describe('resolveExtBare', () => {
   const indexFound = {
     format: 'module',
     shortCircuit: true,
@@ -86,29 +86,51 @@ describe('resolveRelative', () => {
 
   it('does not resolve non-relative paths', () => {
     expect(
-      resolveRelative(INDEX_PATH, ROOT_URL)
+      resolveExtBare(INDEX_PATH, ROOT_URL)
     ).not.toBeDefined();
   });
 
   it('resolves to the index via .', () => {
     expect(
-      resolveRelative('.', SRC_URL)
+      resolveExtBare('.', SRC_URL)
     ).toEqual(indexFound);
   });
 
   it('resolves to the index via ./index', () => {
     expect(
-      resolveRelative('./index', SRC_URL)
+      resolveExtBare('./index', SRC_URL)
     ).toEqual(indexFound);
   });
 
   it('resolves to the sub-directory via ./rootJs', () => {
     expect(
-      resolveRelative('./rootJs', SRC_URL)
+      resolveExtBare('./rootJs', SRC_URL)
     ).toEqual({
       format: 'module',
       shortCircuit: true,
       url: pathToFileURL(`${SRC_PATH}/rootJs/index.ts`).href
+    });
+  });
+
+  it('resolves to extensionless path', () => {
+    expect(
+      resolveExtBare('./packageInfo', SRC_URL)
+    ).toEqual({
+      format: 'module',
+      shortCircuit: true,
+      url: pathToFileURL(`${SRC_PATH}/packageInfo.ts`).href
+    });
+  });
+});
+
+describe('resolveAliases', () => {
+  it('resolves packageInfo', () => {
+    expect(
+      resolveAliases('@polkadot/dev/packageInfo', ROOT_URL)
+    ).toEqual({
+      format: 'module',
+      shortCircuit: true,
+      url: pathToFileURL(`${SRC_PATH}/packageInfo.ts`).href
     });
   });
 });

--- a/packages/dev/src/root.ts
+++ b/packages/dev/src/root.ts
@@ -1,6 +1,6 @@
 // Copyright 2017-2023 @polkadot/dev authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './rootJs';
+export * from './rootJs/index.js';
 
 export const TEST_PURE = /*#__PURE__*/ 'testRoot';

--- a/packages/dev/src/rootCjs.spec.ts
+++ b/packages/dev/src/rootCjs.spec.ts
@@ -9,7 +9,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore This should only run against the compiled ouput, where this should exist
 import testRootBuild from '../build/cjs/root.js';
-import * as testRoot from './root';
-import { runTests } from './rootTests';
+import * as testRoot from './root.js';
+import { runTests } from './rootTests.js';
 
 runTests(testRootBuild as unknown as typeof testRoot);

--- a/packages/dev/src/rootEsm.spec.ts
+++ b/packages/dev/src/rootEsm.spec.ts
@@ -9,7 +9,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore This should only run against the compiled ouput, where this should exist
 import * as testRootBuild from '../build/root.js';
-import * as testRoot from './root';
-import { runTests } from './rootTests';
+import * as testRoot from './root.js';
+import { runTests } from './rootTests.js';
 
 runTests(testRootBuild as unknown as typeof testRoot);

--- a/packages/dev/src/rootJs/Jsx.spec.tsx
+++ b/packages/dev/src/rootJs/Jsx.spec.tsx
@@ -5,7 +5,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { strict as assert } from 'node:assert';
 import React from 'react';
 
-import Jsx from './Jsx';
+import Jsx from './Jsx.js';
 
 describe('react testing', () => {
   it('shows the children when the checkbox is checked', () => {

--- a/packages/dev/src/rootJs/Jsx.tsx
+++ b/packages/dev/src/rootJs/Jsx.tsx
@@ -3,12 +3,12 @@
 
 // Adapted from https://github.com/testing-library/react-testing-library#basic-example
 
-import type { Props } from './JsxChild';
+import type { Props } from './JsxChild.js';
 
 import React, { useCallback, useState } from 'react';
 import styledComponents from 'styled-components';
 
-import Child from './JsxChild';
+import Child from './JsxChild.js';
 
 export const styled = (
   (styledComponents as unknown as { styled: typeof styledComponents }).styled ||

--- a/packages/dev/src/rootJs/index.ts
+++ b/packages/dev/src/rootJs/index.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /** This should appear as-is in the output with: 1. extension added, 2. augmented.d.ts correct */
-import './augmented';
+import './augmented.js';
 
 /** This import should appear as-in in the ouput (cjs without asserts) */
 import testJson from '@polkadot/dev/rootJs/testJson.json' assert { type: 'json' };
 
 /** Double double work, i.e. re-exports */
-export { Clazz } from './Clazz';
+export { Clazz } from './Clazz.js';
 
 /** Function to ensure that BigInt does not have the Babel Math.pow() transform */
 export function bigIntExp (): bigint {

--- a/packages/dev/src/rootJs/test.json.d.ts
+++ b/packages/dev/src/rootJs/test.json.d.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/dev authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-/** This file ahouls not be in the compiled output */
+/** This file should not be in the compiled output */
 
 declare module './testJson.json' {
   declare let contents: { test: { json: 'works' } };

--- a/packages/dev/src/rootSrc.spec.ts
+++ b/packages/dev/src/rootSrc.spec.ts
@@ -1,8 +1,8 @@
 // Copyright 2017-2023 @polkadot/dev authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import * as testRoot from './root';
-import { runTests } from './rootTests';
+import * as testRoot from './root.js';
+import { runTests } from './rootTests.js';
 
 /** This is run against the sources */
 runTests(testRoot);

--- a/packages/dev/src/rootTests.ts
+++ b/packages/dev/src/rootTests.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/dev authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import * as testRoot from './root';
+import * as testRoot from './root.js';
 
 export function runTests ({ Clazz, TEST_PURE, bigIntExp, dynamic, jsOpExp, json }: typeof testRoot): void {
   describe('Clazz', (): void => {


### PR DESCRIPTION
As mentioned in https://github.com/polkadot-js/api/issues/5524

It will probably take quite "some time" to actually roll out (unless there is a lull to expend the effort everywhere)