### PR TITLE
Swap base moduleResolution to nodenext

### DIFF
--- a/packages/dev/config/tsconfig.json
+++ b/packages/dev/config/tsconfig.json
@@ -37,7 +37,6 @@
     "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    /* FIXME Swap this to nodenext as soon as all are on the latest @polkadot/dev that has everything built */
     "moduleResolution": "nodenext",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */

--- a/packages/dev/config/tsconfig.json
+++ b/packages/dev/config/tsconfig.json
@@ -38,7 +38,7 @@
 
     /* Module Resolution Options */
     /* FIXME Swap this to nodenext as soon as all are on the latest @polkadot/dev that has everything built */
-    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "nodenext",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
As per https://github.com/polkadot-js/api/issues/5524

This should be mostly ok now in all the libs - on the end-user apps such as extension/apps there may be more elbow-grease needed to either get them working or swap them to `node`. (Here some dependencies are somewhat problematic)