### PR TITLE
Add module key to export map

### DIFF
--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -378,9 +378,16 @@ function createMapEntry (rootDir, jsPath, noTypes) {
   const hasTypes = !noTypes && jsPath.endsWith('.js') && fs.existsSync(path.join(rootDir, typesPath));
   const field = hasCjs
     ? {
+      // As per TS, the types key needs to be first
       ...(
         hasTypes
           ? { types: typesPath }
+          : {}
+      ),
+      // bundler-specific path, eg. webpack & rollup
+      ...(
+        jsPath.endsWith('.js')
+          ? { module: jsPath }
           : {}
       ),
       require: cjsPath,


### PR DESCRIPTION
In addition to types, import & require, see e.g. https://github.com/uuidjs/uuid/pull/462 (and the linked issues through to e.g. webpack)

This may help with e.g. https://github.com/polkadot-js/api/issues/5636#issuecomment-1538191319