### PR TITLE
Duplicate .d.ts files into cjs

### DIFF
--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -433,10 +433,12 @@ function relativePath (value) {
 function createMapEntry (rootDir, jsPath = '', noTypes) {
   jsPath = relativePath(jsPath);
 
-  const cjsPath = jsPath.replace('./', './cjs/');
-  const hasCjs = fs.existsSync(path.join(rootDir, cjsPath));
   const typesPath = jsPath.replace('.js', '.d.ts');
-  const hasTypes = !noTypes && jsPath.endsWith('.js') && fs.existsSync(path.join(rootDir, typesPath));
+  const cjsPath = jsPath.replace('./', './cjs/');
+  const cjsTypesPath = typesPath.replace('./', './cjs/');
+  const hasCjs = fs.existsSync(path.join(rootDir, cjsPath));
+  const hasTypesCjs = fs.existsSync(path.join(rootDir, cjsTypesPath));
+  const hasTypes = !hasTypesCjs && !noTypes && jsPath.endsWith('.js') && fs.existsSync(path.join(rootDir, typesPath));
   const field = hasCjs
     ? {
       // As per TS, the types key needs to be first
@@ -448,12 +450,21 @@ function createMapEntry (rootDir, jsPath = '', noTypes) {
       // bundler-specific path, eg. webpack & rollup
       ...(
         jsPath.endsWith('.js')
-          ? { module: jsPath }
+          ? hasTypesCjs
+            // eslint-disable-next-line sort-keys
+            ? { module: { types: typesPath, default: jsPath } }
+            : { module: jsPath }
           : {}
       ),
-      require: cjsPath,
+      require: hasTypesCjs
+        // eslint-disable-next-line sort-keys
+        ? { types: cjsTypesPath, default: cjsPath }
+        : cjsPath,
       // eslint-disable-next-line sort-keys
-      default: jsPath
+      default: hasTypesCjs
+        // eslint-disable-next-line sort-keys
+        ? { types: typesPath, default: jsPath }
+        : jsPath
     }
     : hasTypes
       ? {
@@ -491,7 +502,10 @@ function copyBuildFiles (compileType, dir) {
   copyDirSync('src', 'build', ['.patch', '.js', '.cjs', '.mjs', '.json', '.d.ts', '.d.cts', '.d.mts', '.css', '.gif', '.hbs', '.md', '.jpg', '.png', '.rs', '.svg']);
 
   // copy all *.d.ts files
-  copyDirSync([path.join('../../build', dir, 'src'), path.join('../../build/packages', dir, 'src')], 'build', ['.d.ts']);
+  const dtsPaths = ['build-tsc', path.join('../../build', dir, 'src'), path.join('../../build/packages', dir, 'src')];
+
+  copyDirSync(dtsPaths, 'build', ['.d.ts']);
+  copyDirSync(dtsPaths, 'build/cjs', ['.d.ts']);
 
   // copy all from build-{babel|swc|tsc|...}-esm to build
   copyDirSync(`build-${compileType}-esm`, 'build');
@@ -782,6 +796,8 @@ function buildExports () {
 
   pkg.exports = listRoot
     .filter(([path, config]) =>
+      // skip d.ts files
+      !path.endsWith('.d.ts') &&
       // we handle the CJS path at the root below
       path !== './cjs/package.json' &&
       // we don't export ./deno/* paths (e.g. wasm)
@@ -1200,6 +1216,11 @@ async function buildJs (compileType, repoPath, dir, locals) {
   console.log(`*** ${name} ${version}`);
 
   orderPackageJson(repoPath, dir, pkgJson);
+
+  // move the tsc-generated *.d.ts build files to build-tsc
+  if (fs.existsSync('build')) {
+    copyDirSync('build', 'build-tsc', ['.d.ts']);
+  }
 
   if (!fs.existsSync(path.join(process.cwd(), '.skip-build'))) {
     const srcHeader = `// Copyright 2017-${new Date().getFullYear()} ${name} authors & contributors\n// SPDX-License-Identifier: Apache-2.0\n`;


### PR DESCRIPTION
Generates output such as -

```
...
    "./config/typedoc": "./config/typedoc.cjs",
    "./detectOther": {
      "module": {
        "types": "./detectOther.d.ts",
        "default": "./detectOther.js"
      },
      "require": {
        "types": "./cjs/detectOther.d.ts",
        "default": "./cjs/detectOther.js"
      },
      "default": {
        "types": "./detectOther.d.ts",
        "default": "./detectOther.js"
      }
    },
    "./package.json": {
      "require": "./cjs/package.json",
      "default": "./package.json"
    },
...
```

May address https://github.com/polkadot-js/api/issues/5711 (or at worst not make it worse)