### PR TITLE
feat: topological sort for releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.79.1
+
+- feat: add topological sorting to the packages when releasing
+
 ## 0.78.1
 
 - Update internal scripts to dedupe git & yarn commands

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "0.78.13",
+  "version": "0.79.0",
   "versions": {
     "git": "0.78.13",
     "npm": "0.78.13"

--- a/packages/dev-test/package.json
+++ b/packages/dev-test/package.json
@@ -15,7 +15,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "0.78.13",
+  "version": "0.79.0",
   "main": "./index.js",
   "exports": {
     "./globals.d.ts": "./src/globals.d.ts"

--- a/packages/dev-ts/package.json
+++ b/packages/dev-ts/package.json
@@ -15,7 +15,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "0.78.13",
+  "version": "0.79.0",
   "main": "./index.js",
   "exports": {
     "./globals.d.ts": "./src/globals.d.ts"

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -15,7 +15,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "0.78.13",
+  "version": "0.79.0",
   "bin": {
     "polkadot-ci-ghact-build": "./scripts/polkadot-ci-ghact-build.mjs",
     "polkadot-ci-ghact-docs": "./scripts/polkadot-ci-ghact-docs.mjs",
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "@eslint/js": "^8.56.0",
-    "@polkadot/dev-test": "^0.78.13",
-    "@polkadot/dev-ts": "^0.78.13",
+    "@polkadot/dev-test": "^0.79.0",
+    "@polkadot/dev-ts": "^0.79.0",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-dynamic-import-vars": "^2.1.2",

--- a/packages/dev/scripts/polkadot-ci-ghact-build.mjs
+++ b/packages/dev/scripts/polkadot-ci-ghact-build.mjs
@@ -8,7 +8,7 @@ import path from 'node:path';
 import process from 'node:process';
 import yargs from 'yargs';
 
-import { copyDirSync, copyFileSync, denoCreateDir, execGit, execPm, execSync, exitFatal, GITHUB_REPO, GITHUB_TOKEN_URL, gitSetup, logBin, mkdirpSync, rimrafSync } from './util.mjs';
+import { copyDirSync, copyFileSync, denoCreateDir, execGit, execPm, execSync, exitFatal, GITHUB_REPO, GITHUB_TOKEN_URL, gitSetup, logBin, mkdirpSync, rimrafSync, topoSort } from './util.mjs';
 
 /** @typedef {Record<string, any>} ChangelogMap */
 
@@ -492,7 +492,7 @@ skip-checks: true"`);
  */
 function loopFunc (fn) {
   if (fs.existsSync('packages')) {
-    fs
+    const dirs = fs
       .readdirSync('packages')
       .filter((dir) => {
         const pkgDir = path.join(process.cwd(), 'packages', dir);
@@ -500,7 +500,9 @@ function loopFunc (fn) {
         return fs.statSync(pkgDir).isDirectory() &&
           fs.existsSync(path.join(pkgDir, 'package.json')) &&
           fs.existsSync(path.join(pkgDir, 'build'));
-      })
+      });
+
+    topoSort(dirs)
       .forEach((dir) => {
         process.chdir(path.join('packages', dir));
         fn();

--- a/packages/dev/scripts/util.mjs
+++ b/packages/dev/scripts/util.mjs
@@ -436,6 +436,8 @@ export function exitFatalYarn () {
  * Topological sort of dependencies. It handles circular deps by placing them at the end
  * of the sorted array from circular dep with the smallest vertices to the greatest vertices.
  *
+ * Credit to: https://gist.github.com/shinout/1232505 (Parts of this were used as a starting point for the structure of the topoSort)
+ *
  * @param {string[]} dirs
  */
 export function topoSort (dirs) {

--- a/packages/dev/scripts/util.mjs
+++ b/packages/dev/scripts/util.mjs
@@ -435,7 +435,7 @@ export function exitFatalYarn () {
 /**
  * Topological sort of dependencies. It handles circular deps by placing them at the end
  * of the sorted array from circular dep with the smallest vertices to the greatest vertices.
- * 
+ *
  * @param {string[]} dirs
  */
 export function topoSort (dirs) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,7 +433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/dev-test@npm:^0.78.13, @polkadot/dev-test@workspace:packages/dev-test":
+"@polkadot/dev-test@npm:^0.79.0, @polkadot/dev-test@workspace:packages/dev-test":
   version: 0.0.0-use.local
   resolution: "@polkadot/dev-test@workspace:packages/dev-test"
   dependencies:
@@ -443,7 +443,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/dev-ts@npm:^0.78.13, @polkadot/dev-ts@workspace:packages/dev-ts":
+"@polkadot/dev-ts@npm:^0.79.0, @polkadot/dev-ts@workspace:packages/dev-ts":
   version: 0.0.0-use.local
   resolution: "@polkadot/dev-ts@workspace:packages/dev-ts"
   dependencies:
@@ -458,8 +458,8 @@ __metadata:
   resolution: "@polkadot/dev@workspace:packages/dev"
   dependencies:
     "@eslint/js": "npm:^8.56.0"
-    "@polkadot/dev-test": "npm:^0.78.13"
-    "@polkadot/dev-ts": "npm:^0.78.13"
+    "@polkadot/dev-test": "npm:^0.79.0"
+    "@polkadot/dev-ts": "npm:^0.79.0"
     "@rollup/plugin-alias": "npm:^5.1.0"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-dynamic-import-vars": "npm:^2.1.2"


### PR DESCRIPTION
## Summary

The following adds topological sorting for a workspace and it's corresponding packages. Unfortunately not all `@polkadot/*` are able to be ordered with full topological integrity as some repos have circular deps. That being said this is one avenue to help the releases be more fault tolerant and will help avoid situations like: https://github.com/polkadot-js/api/issues/5841

### Circular dependencies

The current algorithm deals with circular dependencies by adding them to the end of the sorted vector. The order in which it adds them is based on the length of their vertices. This is from least to greatest. 

closes: https://github.com/polkadot-js/dev/issues/1139