### PR TITLE
Fix topo sort for single dirs

### DIFF
--- a/packages/dev/scripts/util.mjs
+++ b/packages/dev/scripts/util.mjs
@@ -450,6 +450,10 @@ export function topoSort (dirs) {
   /** @type {Record<string, Node>} */
   const circular = {};
 
+  if (dirs.length === 1) {
+    return dirs;
+  }
+
   class Node {
     /** @param {string} id  */
     constructor (id) {


### PR DESCRIPTION
When packages have a single package topo sort will return nothing. Therefore we need to attach an edge case where length === 1 return the same `dirs`.