### PR TITLE
Fix topo sort for standAlone packages

### DIFF
--- a/packages/dev/scripts/util.mjs
+++ b/packages/dev/scripts/util.mjs
@@ -531,5 +531,10 @@ export function topoSort (dirs) {
   const circularSorted = Object.keys(circular)
     .sort((a, b) => circular[a].vertices.length < circular[b].vertices.length ? -1 : 1);
 
-  return sorted.concat(circularSorted);
+  const flattenedEdges = edges.flat();
+  // Packages that have no edges
+  /** @type {string[]} */
+  const standAlones = dirs.filter((d) => !flattenedEdges.includes(d));
+
+  return sorted.concat(circularSorted).concat(standAlones);
 }


### PR DESCRIPTION
When packages have no edges they should still be added to the topo sort result.