### PR TITLE
Write the Buffer Import to necessary Deno build files

### DIFF
--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -410,7 +410,7 @@ function rewriteImports (dir, pkgCwd, pkgJson, replacer) {
  * @param {string} dir - Directory to traverse.
  * @param {string} pkgCwd - Current working directory of the package.
  */
-function addBufferImportForDeno(dir, pkgCwd) {
+function addBufferImportForDeno (dir, pkgCwd) {
   if (!fs.existsSync(dir)) {
     return;
   }
@@ -426,12 +426,12 @@ function addBufferImportForDeno(dir, pkgCwd) {
 
       if (content.includes('Buffer') && !content.includes("import { Buffer } from 'node:buffer';")) {
         const updatedContent = `import { Buffer } from 'node:buffer';\n\n${content}`;
+
         fs.writeFileSync(filePath, updatedContent, 'utf-8');
       }
     }
   });
 }
-
 
 function buildDeno () {
   const pkgCwd = process.cwd();

--- a/packages/dev/scripts/polkadot-dev-build-ts.mjs
+++ b/packages/dev/scripts/polkadot-dev-build-ts.mjs
@@ -273,8 +273,6 @@ function adjustDenoPath (pkgCwd, pkgJson, dir, f, isDeclare) {
     // Since Deno 1.28 the node: specifiers is supported out-of-the-box
     // so we just return and use these as-is
     return f;
-  } else if (f === '@types/node') {
-    return null
   }
 
   const depParts = f.split('/');


### PR DESCRIPTION
# Summary

Introduced in deno v2, the Buffer type is no longer part of global. This has extended in our CI to the 1.x versions as well (I really don't know why after hours of looking). To solve this wherever the type is used in the deno build we adjust the imports to include the Buffer import from `node:buffer` specifically. This will solve our build issues we currently have in all our CI's, and should allow us to update our deno ci builds to lts